### PR TITLE
replace the spotcrime Api key with spotcrime-api-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 SpotCrime doesn't really like people using their API, so this module is certainly not something you should build more than a prototype on top of. The keys change constantly and they purposefully try to break this module on a regular basis.
 
+The current workaround for an api key is to use the SpotCrime map web interface and inspect the network traffic for a key. The request will be to https://spotcrime.com/crimes.json and you will need the spotcrime-api-token header. Replace the example key in lib\getCrimes.js with this token.
+
 If you need a consistent source of 911 call / police report / other municipal data, you should use https://municipal.systems/ instead.
 
 ## Usage

--- a/lib/getCrimes.js
+++ b/lib/getCrimes.js
@@ -1,22 +1,23 @@
 var request = require('superagent');
+var baseUrl = 'http://spotcrime.com/crimes.json';
 
-var baseUrl = 'http://api.spotcrime.com/crimes.json';
-var key = 'This-api-key-is-for-commercial-use-exclusively.Only-entities-with-a-Spotcrime-contract-May-use-this-key.Call-877.410.1607.';
+//example key
+var spotCrimeApiToken = 'SFMyNTY.g2gDbQAAACQ1NjE4MDc1Ny00YWIwLTQ1YTMtYmUzOC0zZjU1OTc3MTc1MTluBgBNGK4ZfgFiAAFRgA.zoNkVc3npkM7Nrt2EW6AJ8cVNqucCUP1g7BLrE5LsUE';
 
 module.exports = function(loc, radius, cb) {
   if (typeof radius === 'function') {
     cb = radius;
     radius = null;
   }
-  if (!radius) radius = 0.01;
+    if (!radius) radius = 0.01;
   const out = request.get(baseUrl)
     .type('json')
     .query({
       lat: loc.lat,
       lon: loc.lon,
-      key: key,
       radius: radius
-    }).then(({ body }) => body && body.crimes)
+    }).set('spotcrime-api-token', spotCrimeApiToken)
+      .then(({ body }) => body && body.crimes)
   if (!cb) return out
 
 


### PR DESCRIPTION
This replaces the api key with the spotcrime-api-token header.

While the previous commit will work, it seems to be locked to Phoenix, AZ. using the keys found in this way will allow for access to any location.

I don't really like how the process for getting a new key is kind of tedious, but this will give users a way to get data for any location.